### PR TITLE
Fixed unix highscore file creation

### DIFF
--- a/src/de/thdeg/snake/highScore/HighscoreIO.java
+++ b/src/de/thdeg/snake/highScore/HighscoreIO.java
@@ -25,7 +25,7 @@ public class HighscoreIO {
     public String refreshHighscore(String difficulty, int score){
 
         String path = Paths.get(getAppdataDir(), "Snake").toString();
-        String filepath = path + "\\" + difficulty + ".snake";
+        String filepath = path + File.separator + difficulty + ".snake";
 
         createDirectoryIfNotExists(path);
 


### PR DESCRIPTION
Habe für Unix-Systeme die Pfaderstellung für die Highscore-Dateien gefixt